### PR TITLE
Bump org.web3j:web3j-maven-plugin from 0.3.7 to 4.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <web3j.version>3.6.0</web3j.version>
         <logback-classic.version>1.2.3</logback-classic.version>
-        <web3j-maven-plugin.version>0.3.7</web3j-maven-plugin.version>
+        <web3j-maven-plugin.version>4.10.3</web3j-maven-plugin.version>
         <junit.version>4.12</junit.version>
         <exec-maven-plugin>1.6.0</exec-maven-plugin>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Bumps org.web3j:web3j-maven-plugin from 0.3.7 to 4.10.3.
